### PR TITLE
[Needs Review] implementing backward compatible follow multi-target

### DIFF
--- a/example/allfeature/camera_controls.gui_script
+++ b/example/allfeature/camera_controls.gui_script
@@ -55,7 +55,7 @@ end
 
 local function post_follow_message(self)
 	msg.post(CAMERA_ID, "follow", {
-		target = "/player",
+		target = {"/player2", "/player"},
 		lerp = self.lerp,
 		offset = self.camera_offset,
 		horizontal = self.follow_horizontal,

--- a/example/allfeature/example.collection
+++ b/example/allfeature/example.collection
@@ -282,3 +282,43 @@ embedded_instances {
     z: 1.0
   }
 }
+embedded_instances {
+  id: "player2"
+  data: "embedded_components {\n"
+  "  id: \"sprite\"\n"
+  "  type: \"sprite\"\n"
+  "  data: \"tile_set: \\\"/example/assets/examples.atlas\\\"\\n"
+  "default_animation: \\\"hitman1_gun\\\"\\n"
+  "material: \\\"/builtins/materials/sprite.material\\\"\\n"
+  "blend_mode: BLEND_MODE_ALPHA\\n"
+  "\"\n"
+  "  position {\n"
+  "    x: -83.0\n"
+  "    y: -220.0\n"
+  "    z: 0.0\n"
+  "  }\n"
+  "  rotation {\n"
+  "    x: 0.0\n"
+  "    y: 0.0\n"
+  "    z: 0.0\n"
+  "    w: 1.0\n"
+  "  }\n"
+  "}\n"
+  ""
+  position {
+    x: 414.889
+    y: 640.951
+    z: 1.0
+  }
+  rotation {
+    x: 0.0
+    y: 0.0
+    z: 0.0
+    w: 1.0
+  }
+  scale3 {
+    x: 1.0
+    y: 1.0
+    z: 1.0
+  }
+}

--- a/orthographic/camera.lua
+++ b/orthographic/camera.lua
@@ -42,6 +42,7 @@ local v4_tmp = vmath.vector4()
 local v3_tmp = vmath.vector3()
 
 local cameras = {}
+local targets = {}
 
 --- projection providers (projectors)
 -- a mapping of id to function to calculate and return a projection matrix
@@ -193,6 +194,30 @@ local function calculate_view(camera, camera_world_pos, offset)
 	return view
 end
 
+--- Return target tables
+function M.get_targets()
+	return targets
+end
+
+--- Set targets
+-- @param message_targets
+function M.set_targets(message_targets)
+	targets = {}
+	if type(message_targets) == "table" then
+		for i = 1, #message_targets do
+			if type(message_targets[i]) == "string" then
+				table.insert(targets, hash(message_targets[i]))
+			else
+				table.insert(targets, message_targets[i])
+			end
+		end
+	elseif type(message_targets) == "string" then
+		table.insert(targets, hash(message_targets))
+	else
+		table.insert(targets, message_targets)
+	end
+end
+
 
 --- Initialize a camera
 -- Note: This is called automatically from the init() function of the camera.script
@@ -249,9 +274,12 @@ function M.update(camera_id, dt)
 	if follow_enabled then
 		local follow_horizontal = go.get(camera.url, "follow_horizontal")
 		local follow_vertical = go.get(camera.url, "follow_vertical")
-		local follow = go.get(camera.url, "follow_target")
 		local follow_offset = go.get(camera.url, "follow_offset")
-		local target_world_pos = go.get_world_position(follow) + follow_offset
+		local target_world_pos = go.get_world_position(targets[1])
+		for i = 2, #targets do
+			target_world_pos = target_world_pos + go.get_world_position(targets[i])
+		end
+		target_world_pos = target_world_pos / #targets + follow_offset
 		local new_pos
 		local deadzone_top = go.get(camera.url, "deadzone_top")
 		local deadzone_left = go.get(camera.url, "deadzone_left")

--- a/orthographic/camera.script
+++ b/orthographic/camera.script
@@ -42,13 +42,26 @@ local ZOOM_TO = hash("zoom_to")
 local USE_PROJECTION = hash("use_projection")
 
 local function position_on_follow(self)
-	local target_position = go.get_position(self.follow_target)
+	local targets = camera.get_targets()
 	local camera_position = go.get_position()
-	target_position.z = camera_position.z
+	local target_position
+	if #targets == 0 then
+		target_position = camera_position
+	else
+		target_position = vmath.vector3()
+		for i = 1, #targets do
+			target_position = target_position + go.get_position(targets[i])
+		end
+		target_position = target_position / #targets
+		target_position.z = camera_position.z
+	end
 	go.set_position(target_position)
 end
 
 function init(self)
+	if self.follow then
+		camera.set_targets(self.follow_target)
+	end
 	camera.init(go.get_id(), msg.url(), { zoom = self.zoom })
 	if self.enabled then
 		camera.update(go.get_id(), 0)
@@ -97,7 +110,7 @@ function on_message(self, message_id, message, sender)
 		if message.vertical == nil then message.vertical = true end
 		self.follow_horizontal = message.horizontal
 		self.follow_vertical = message.vertical
-		self.follow_target = type(message.target) == "string" and hash(message.target) or message.target
+		camera.set_targets(message.target)
 		self.follow_lerp = message.lerp or 1
 		self.follow_offset = message.offset or vmath.vector3()
 		self.follow_immediately = message.immediate


### PR DESCRIPTION
So what I did was move target tables to camera module instead of camera script but kept target properties inside camera script because removing it cases a big compatibility issue (forcing devs to select follow target only with code). but the value of this property ignores and inside camera script init function it's value will be sent to targets that's inside camera module.
the only issue is if someone changes the target property directly in the middle of the game with go property instead of using `follow` function call or msg, the changed value will not affect anything

and it needs a better example implementation