### PR TITLE
Reduce allocations on update

### DIFF
--- a/orthographic/camera.lua
+++ b/orthographic/camera.lua
@@ -326,6 +326,21 @@ function M.update(camera_id, dt)
 		return
 	end
 
+	local viewport_top = go.get(camera.url, "viewport_top")
+	local viewport_left = go.get(camera.url, "viewport_left")
+	local viewport_bottom = go.get(camera.url, "viewport_bottom")
+	local viewport_right = go.get(camera.url, "viewport_right")
+	if viewport_top == 0 then
+		viewport_top = WINDOW_HEIGHT
+	end
+	if viewport_right == 0 then
+		viewport_right = WINDOW_WIDTH
+	end
+	camera.viewport.x = viewport_left
+	camera.viewport.y = viewport_bottom
+	camera.viewport.z = math.max(viewport_right - viewport_left, 1)
+	camera.viewport.w = math.max(viewport_top - viewport_bottom, 1)
+
 	update_window_size()
 
 	local camera_world_pos = go.get_world_position(camera_id)
@@ -407,21 +422,6 @@ function M.update(camera_id, dt)
 
 		camera_world_pos = M.screen_to_world(camera_id, cp)
 	end
-
-	local viewport_top = go.get(camera.url, "viewport_top")
-	local viewport_left = go.get(camera.url, "viewport_left")
-	local viewport_bottom = go.get(camera.url, "viewport_bottom")
-	local viewport_right = go.get(camera.url, "viewport_right")
-	if viewport_top == 0 then
-		viewport_top = WINDOW_HEIGHT
-	end
-	if viewport_right == 0 then
-		viewport_right = WINDOW_WIDTH
-	end
-	camera.viewport.x = viewport_left
-	camera.viewport.y = viewport_bottom
-	camera.viewport.z = math.max(viewport_right - viewport_left, 1)
-	camera.viewport.w = math.max(viewport_top - viewport_bottom, 1)
 
 	go.set_position(camera_world_pos + camera_world_to_local_diff, camera_id)
 

--- a/orthographic/camera.lua
+++ b/orthographic/camera.lua
@@ -603,7 +603,7 @@ end
 -- @param duration Duration of the recoil. Optional, default: 0.5s.
 function M.recoil(camera_id, offset, duration)
 	camera_id = camera_id or camera_ids[1]
-	assert(camera_id, "You must provide a strength id")
+	assert(camera_id, "You must provide a camera id")
 	cameras[camera_id].recoil = {
 		offset = offset,
 		duration = duration or 0.5,

--- a/orthographic/camera.lua
+++ b/orthographic/camera.lua
@@ -326,6 +326,11 @@ function M.update(camera_id, dt)
 		return
 	end
 
+	camera.projection_id = go.get(camera.url, "projection")
+	camera.near_z = go.get(camera.url, "near_z")
+	camera.far_z = go.get(camera.url, "far_z")
+	camera.zoom = go.get(camera.url, "zoom")
+
 	local viewport_top = go.get(camera.url, "viewport_top")
 	local viewport_left = go.get(camera.url, "viewport_left")
 	local viewport_bottom = go.get(camera.url, "viewport_bottom")
@@ -463,10 +468,6 @@ function M.update(camera_id, dt)
 	end
 	camera.offset = offset
 
-	camera.projection_id = go.get(camera.url, "projection")
-	camera.near_z = go.get(camera.url, "near_z")
-	camera.far_z = go.get(camera.url, "far_z")
-	camera.zoom = go.get(camera.url, "zoom")
 	camera.view = calculate_view(camera, camera_world_pos, offset)
 	camera.projection = calculate_projection(camera)
 

--- a/orthographic/camera.lua
+++ b/orthographic/camera.lua
@@ -490,32 +490,34 @@ function M.update(camera_id, dt)
 	go.set_position(v3_tmp, camera_id)
 
 
-	if camera.shake then
-		camera.shake.duration = camera.shake.duration - dt
-		if camera.shake.duration < 0 then
-			if camera.shake.cb then camera.shake.cb() end
-			camera.shake = nil
+	local shake = camera.shake
+	if shake then
+		shake.duration = shake.duration - dt
+		if shake.duration < 0 then
+			if shake.cb then shake.cb() end
+			camera.shake, shake = nil, nil
 		else
-			if camera.shake.horizontal then
-				camera.shake.offset.x = (DISPLAY_WIDTH * camera.shake.intensity) * (math.random() - 0.5)
+			if shake.horizontal then
+				shake.offset.x = (DISPLAY_WIDTH * shake.intensity) * (math.random() - 0.5)
 			end
-			if camera.shake.vertical then
-				camera.shake.offset.y = (DISPLAY_WIDTH * camera.shake.intensity) * (math.random() - 0.5)
+			if shake.vertical then
+				shake.offset.y = (DISPLAY_WIDTH * shake.intensity) * (math.random() - 0.5)
 			end
 		end
 	end
 
-	if camera.recoil then
-		camera.recoil.time_left = camera.recoil.time_left - dt
-		if camera.recoil.time_left < 0 then
-			camera.recoil = nil
+	local recoil = camera.recoil
+	if recoil then
+		recoil.time_left = recoil.time_left - dt
+		if recoil.time_left < 0 then
+			camera.recoil, recoil = nil, nil
 		else
-			local t = camera.recoil.time_left / camera.recoil.duration
-			camera.recoil.offset = vmath.lerp(t, VECTOR3_ZERO, camera.recoil.offset)
+			local t = recoil.time_left / recoil.duration
+			recoil.offset = vmath.lerp(t, VECTOR3_ZERO, recoil.offset)
 		end
 	end
 
-	if camera.shake or camera.recoil then
+	if shake or recoil then
 		local offset = camera.offset
 		if offset then
 			offset.x = 0
@@ -525,15 +527,15 @@ function M.update(camera_id, dt)
 			offset = vmath.vector3()
 			camera.offset = offset
 		end
-		if camera.shake then
-			offset.x = offset.x + camera.shake.offset.x
-			offset.y = offset.y + camera.shake.offset.y
-			offset.z = offset.z + camera.shake.offset.z
+		if shake then
+			offset.x = offset.x + shake.offset.x
+			offset.y = offset.y + shake.offset.y
+			offset.z = offset.z + shake.offset.z
 		end
-		if camera.recoil then
-			offset.x = offset.x + camera.recoil.offset.x
-			offset.y = offset.y + camera.recoil.offset.y
-			offset.z = offset.z + camera.recoil.offset.z
+		if recoil then
+			offset.x = offset.x + recoil.offset.x
+			offset.y = offset.y + recoil.offset.y
+			offset.z = offset.z + recoil.offset.z
 		end
 	else
 		camera.offset = nil

--- a/orthographic/camera.lua
+++ b/orthographic/camera.lua
@@ -355,8 +355,9 @@ function M.update(camera_id, dt)
 		return
 	end
 
-	local enabled = go.get(camera.url, "enabled")
-	local order = go.get(camera.url, "order")
+	local camera_url = camera.url
+	local enabled = go.get(camera_url, "enabled")
+	local order = go.get(camera_url, "order")
 	cameras_dirty = cameras_dirty or (camera.enabled ~= enabled)
 	cameras_dirty = cameras_dirty or (camera.order ~= order)
 	camera.enabled = enabled
@@ -365,15 +366,15 @@ function M.update(camera_id, dt)
 		return
 	end
 
-	camera.projection_id = go.get(camera.url, "projection")
-	camera.near_z = go.get(camera.url, "near_z")
-	camera.far_z = go.get(camera.url, "far_z")
-	camera.zoom = go.get(camera.url, "zoom")
+	camera.projection_id = go.get(camera_url, "projection")
+	camera.near_z = go.get(camera_url, "near_z")
+	camera.far_z = go.get(camera_url, "far_z")
+	camera.zoom = go.get(camera_url, "zoom")
 
-	local viewport_top = go.get(camera.url, "viewport_top")
-	local viewport_left = go.get(camera.url, "viewport_left")
-	local viewport_bottom = go.get(camera.url, "viewport_bottom")
-	local viewport_right = go.get(camera.url, "viewport_right")
+	local viewport_top = go.get(camera_url, "viewport_top")
+	local viewport_left = go.get(camera_url, "viewport_left")
+	local viewport_bottom = go.get(camera_url, "viewport_bottom")
+	local viewport_right = go.get(camera_url, "viewport_right")
 	if viewport_top == 0 then
 		viewport_top = WINDOW_HEIGHT
 	end
@@ -392,23 +393,23 @@ function M.update(camera_id, dt)
 	camera_world_to_local_diff.x = camera_world_to_local_diff.x - camera_world_pos.x
 	camera_world_to_local_diff.y = camera_world_to_local_diff.y - camera_world_pos.y
 	camera_world_to_local_diff.z = camera_world_to_local_diff.z - camera_world_pos.z
-	local follow_enabled = go.get(camera.url, "follow")
+	local follow_enabled = go.get(camera_url, "follow")
 	if follow_enabled then
-		local follow = go.get(camera.url, "follow_target")
+		local follow = go.get(camera_url, "follow_target")
 		if not check_game_object(follow) then
 			log("Camera '%s' has a follow target '%s' that does not exist", tostring(camera_id), tostring(follow))
 		else
-			local follow_horizontal = go.get(camera.url, "follow_horizontal")
-			local follow_vertical = go.get(camera.url, "follow_vertical")
-			local follow_offset = go.get(camera.url, "follow_offset")
+			local follow_horizontal = go.get(camera_url, "follow_horizontal")
+			local follow_vertical = go.get(camera_url, "follow_vertical")
+			local follow_offset = go.get(camera_url, "follow_offset")
 			local new_pos = go.get_world_position(follow)
 			new_pos.x = new_pos.x + follow_offset.x
 			new_pos.y = new_pos.y + follow_offset.y
 			new_pos.z = camera_world_pos.z
-			local deadzone_top = go.get(camera.url, "deadzone_top")
-			local deadzone_left = go.get(camera.url, "deadzone_left")
-			local deadzone_right = go.get(camera.url, "deadzone_right")
-			local deadzone_bottom = go.get(camera.url, "deadzone_bottom")
+			local deadzone_top = go.get(camera_url, "deadzone_top")
+			local deadzone_left = go.get(camera_url, "deadzone_left")
+			local deadzone_right = go.get(camera_url, "deadzone_right")
+			local deadzone_bottom = go.get(camera_url, "deadzone_bottom")
 			if deadzone_top ~= 0 or deadzone_left ~= 0 or deadzone_right ~= 0 or deadzone_bottom ~= 0 then
 				local left_edge = camera_world_pos.x - deadzone_left
 				local right_edge = camera_world_pos.x + deadzone_right
@@ -435,16 +436,16 @@ function M.update(camera_id, dt)
 			if not follow_horizontal then
 				new_pos.x = camera_world_pos.x
 			end
-			local follow_lerp = go.get(camera.url, "follow_lerp")
+			local follow_lerp = go.get(camera_url, "follow_lerp")
 			camera_world_pos = lerp_with_dt(follow_lerp, dt, camera_world_pos, new_pos)
 			camera_world_pos.z = new_pos.z
 		end
 	end
 
-	local bounds_top = go.get(camera.url, "bounds_top")
-	local bounds_left = go.get(camera.url, "bounds_left")
-	local bounds_bottom = go.get(camera.url, "bounds_bottom")
-	local bounds_right = go.get(camera.url, "bounds_right")
+	local bounds_top = go.get(camera_url, "bounds_top")
+	local bounds_left = go.get(camera_url, "bounds_left")
+	local bounds_bottom = go.get(camera_url, "bounds_bottom")
+	local bounds_right = go.get(camera_url, "bounds_right")
 	if bounds_top ~= 0 or bounds_left ~= 0 or bounds_bottom ~= 0 or bounds_right ~= 0 then
 		local viewport = camera.viewport
 		local viewport_w = viewport.z * DISPLAY_WIDTH / WINDOW_WIDTH

--- a/orthographic/camera.script
+++ b/orthographic/camera.script
@@ -64,13 +64,14 @@ end
 function update(self, dt)
 	-- update camera and view projection after all game objects have been updated
 	-- will jitter otherwise
-	msg.post("#", camera.MSG_UPDATE_CAMERA, { dt = dt })
+	self.last_dt = dt
+	msg.post("#", camera.MSG_UPDATE_CAMERA)
 end
 
 
 function on_message(self, message_id, message, sender)
 	if message_id == camera.MSG_UPDATE_CAMERA then
-		camera.update(go.get_id(), message.dt)
+		camera.update(go.get_id(), message.dt or self.last_dt)
 		if self.enabled then
 			camera.send_view_projection(go.get_id())
 		end

--- a/orthographic/render/orthographic.render_script
+++ b/orthographic/render/orthographic.render_script
@@ -12,29 +12,33 @@ function init(self)
 	self.text_pred = render.predicate({"text"})
 	self.particle_pred = render.predicate({"particle"})
 
-	self.clear_color = vmath.vector4(0, 0, 0, 0)
-	self.clear_color.x = sys.get_config("render.clear_color_red", 0)
-	self.clear_color.y = sys.get_config("render.clear_color_green", 0)
-	self.clear_color.z = sys.get_config("render.clear_color_blue", 0)
-	self.clear_color.w = sys.get_config("render.clear_color_alpha", 0)
+	local clear_color = vmath.vector4()
+	clear_color.x = sys.get_config("render.clear_color_red", 0)
+	clear_color.y = sys.get_config("render.clear_color_green", 0)
+	clear_color.z = sys.get_config("render.clear_color_blue", 0)
+	clear_color.w = sys.get_config("render.clear_color_alpha", 0)
+	self.clear_buffers = {[render.BUFFER_COLOR_BIT] = clear_color, [render.BUFFER_DEPTH_BIT] = 1, [render.BUFFER_STENCIL_BIT] = 0}
+
+	self.camera_draw_options = {frustum = vmath.matrix4()}
+	self.gui_draw_options = {frustum = vmath.matrix4_orthographic(0, render.get_window_width(), 0, render.get_window_height(), -1, 1)}
 end
 
 function update(self)
 	-- clear color
 	render.set_depth_mask(true)
 	render.set_stencil_mask(0xff)
-	render.clear({[render.BUFFER_COLOR_BIT] = self.clear_color, [render.BUFFER_DEPTH_BIT] = 1, [render.BUFFER_STENCIL_BIT] = 0})
+	render.clear(self.clear_buffers)
 	render.set_depth_mask(false)
-	
+
 	-- set default blend state
 	render.enable_state(render.STATE_BLEND)
 	render.set_blend_func(render.BLEND_SRC_ALPHA, render.BLEND_ONE_MINUS_SRC_ALPHA)
 
 	-- draw world per camera
+	local camera_draw_options = self.camera_draw_options
+	local tile_pred = self.tile_pred
+	local particle_pred = self.particle_pred
 	local cameras = camera.get_cameras()
-	local frustum = nil
-	local view = nil
-	local proj = nil
 	if #cameras > 0 then
 		render.disable_state(render.STATE_DEPTH_TEST)
 		render.disable_state(render.STATE_CULL_FACE)
@@ -42,34 +46,37 @@ function update(self)
 		for _,camera_id in ipairs(cameras) do
 			local viewport = camera.get_viewport(camera_id)
 			render.set_viewport(viewport.x, viewport.y, viewport.z, viewport.w)
-			view = camera.get_view(camera_id)
+			local view = camera.get_view(camera_id)
 			render.set_view(view)
-			proj = camera.get_projection(camera_id)
+			local proj = camera.get_projection(camera_id)
 			render.set_projection(proj)
-			frustum = proj * view
-			render.draw(self.tile_pred, {frustum = frustum})
-			render.draw(self.particle_pred, {frustum = frustum})
+			camera_draw_options.frustum = proj * view
+			render.draw(tile_pred, camera_draw_options)
+			render.draw(particle_pred, camera_draw_options)
 			render.draw_debug3d()
 		end
 	end
-	
+
 	-- draw gui in screen space using an orthographic projection
 	render.disable_state(render.STATE_DEPTH_TEST)
 	render.disable_state(render.STATE_CULL_FACE)
 	render.enable_state(render.STATE_STENCIL_TEST)
-	render.set_viewport(0, 0, render.get_window_width(), render.get_window_height())
-	view = IDENTITY
-	render.set_view(view)
-	proj = vmath.matrix4_orthographic(0, render.get_window_width(), 0, render.get_window_height(), -1, 1)
-	render.set_projection(proj)
-	frustum = proj * view
-	render.draw(self.gui_pred, {frustum = frustum})
-	render.draw(self.text_pred, {frustum = frustum})
+	local window_width = render.get_window_width()
+	local window_height = render.get_window_height()
+	render.set_viewport(0, 0, window_width, window_height)
+	render.set_view(IDENTITY)
+	local gui_draw_options = self.gui_draw_options
+	local gui_proj = gui_draw_options.frustum
+	gui_proj.m00 = 2 / window_width
+	gui_proj.m11 = 2 / window_height
+	render.set_projection(gui_proj)
+	render.draw(self.gui_pred, gui_draw_options)
+	render.draw(self.text_pred, gui_draw_options)
 	render.disable_state(render.STATE_STENCIL_TEST)
 end
 
 function on_message(self, message_id, message)
 	if message_id == CLEAR_COLOR then
-		self.clear_color = message.color
+		self.clear_buffers[render.BUFFER_COLOR_BIT] = message.color
 	end
 end


### PR DESCRIPTION
I've removed unnecessary allocations in the render_script and camera module update functions. I've also re-ordered a couple of things and added a few locals for readability and convenience.

In camera's update this results in a ~22% reduction. Unfortunately, the garbage produced by the many calls to `go.get` is quite significant, ~5000B, so the reduction of vmath garbage by ~1500B doesn't look so great in comparison.

The code is arguably a bit less readable and elegant; feel free to reject some or all of these changes.