### PR TITLE
Smaller fixes to examples

### DIFF
--- a/example/allfeatures/allfeatures.collection
+++ b/example/allfeatures/allfeatures.collection
@@ -16,11 +16,6 @@ instances {
   component_properties {
     id: "script"
     properties {
-      id: "zoom"
-      value: "1.0"
-      type: PROPERTY_TYPE_NUMBER
-    }
-    properties {
       id: "projection"
       value: "FIXED_ZOOM"
       type: PROPERTY_TYPE_HASH
@@ -90,7 +85,7 @@ instances {
     }
     properties {
       id: "camera_offset_lerp"
-      value: "0.01"
+      value: "0.0"
       type: PROPERTY_TYPE_NUMBER
     }
   }
@@ -116,6 +111,8 @@ embedded_instances {
   "    y: 0.0\n"
   "    z: 0.0\n"
   "    w: 1.0\n"
+  "  }\n"
+  "  property_decls {\n"
   "  }\n"
   "}\n"
   ""
@@ -151,6 +148,8 @@ embedded_instances {
   "    y: 0.0\n"
   "    z: 0.0\n"
   "    w: 1.0\n"
+  "  }\n"
+  "  property_decls {\n"
   "  }\n"
   "}\n"
   ""

--- a/example/allfeatures/allfeatures.collection
+++ b/example/allfeatures/allfeatures.collection
@@ -68,7 +68,7 @@ instances {
   position {
     x: 344.0
     y: 321.0
-    z: 1.0
+    z: 0.5
   }
   rotation {
     x: 0.0

--- a/example/allfeatures/camera_controls.gui_script
+++ b/example/allfeatures/camera_controls.gui_script
@@ -67,6 +67,22 @@ local function post_follow_message(self)
 	})
 end
 
+local function update_deadzone(self, zoomlevel)
+	local dz = gui.get_node("deadzone_visualizer")
+	gui.set_enabled(dz, self.deadzone_enabled)
+	if self.deadzone_enabled then
+		local w = 600
+		local h = 400
+		gui.set_size(dz, vmath.vector3(w, h, 0))
+		local inv_zoomlevel = 1 / zoomlevel
+		w = (w * inv_zoomlevel) / 2
+		h = (h * inv_zoomlevel) / 2
+		msg.post(CAMERA_ID, "deadzone", { left = w, right = w, bottom = h, top = h })
+	else
+		msg.post(CAMERA_ID, "deadzone", {})
+	end
+end
+
 function on_input(self, action_id, action)
 	if action_id == hash("touch") and action.released then
 		if gui.pick_node(gui.get_node("unfollow/button"), action.x, action.y) then
@@ -125,23 +141,16 @@ function on_input(self, action_id, action)
 			return true
 		elseif gui.pick_node(gui.get_node("deadzone/button"), action.x, action.y) then
 			self.deadzone_enabled = not self.deadzone_enabled
-			local dz = gui.get_node("deadzone_visualizer")
-			gui.set_enabled(dz, self.deadzone_enabled)
-			if self.deadzone_enabled then
-				local w = 600
-				local h = 400
-				gui.set_size(dz, vmath.vector3(w, h, 0))
-				msg.post(CAMERA_ID, "deadzone", { left = w/2, right = w/2, bottom = h/2, top = h/2 })
-			else
-				msg.post(CAMERA_ID, "deadzone", {})
-			end
+			update_deadzone(self, camera.get_zoom(CAMERA_ID))
 			return true
 		elseif gui.pick_node(gui.get_node("zoomin/button"), action.x, action.y) then
 			local zoomlevel = camera.get_zoom(CAMERA_ID) + 0.25
+			update_deadzone(self, zoomlevel)
 			msg.post(CAMERA_ID, "zoom_to", { zoom = zoomlevel } )
 			return true
 		elseif gui.pick_node(gui.get_node("zoomout/button"), action.x, action.y) then
 			local zoomlevel = math.max(0.25, camera.get_zoom(CAMERA_ID) - 0.25)
+			update_deadzone(self, zoomlevel)
 			msg.post(CAMERA_ID, "zoom_to", { zoom = zoomlevel } )
 			return true
 		elseif gui.pick_node(gui.get_node("change_projection/button"), action.x, action.y) then

--- a/example/allfeatures/camera_controls.gui_script
+++ b/example/allfeatures/camera_controls.gui_script
@@ -21,7 +21,6 @@ function init(self)
 	self.deadzone_enabled = false
 	self.current_projection = 1
 	self.lerp = 0
-	msg.post("#", "use_projector")
 end
 
 local function get_scaling_factor()
@@ -151,8 +150,6 @@ function on_input(self, action_id, action)
 			camera.use_projector(CAMERA_ID, PROJECTIONS[self.current_projection])
 			return true
 		end
-	elseif message_id == hash("use_projector") then
-		camera.use_projector(CAMERA_ID, PROJECTIONS[self.current_projection])
 	end
 end
 

--- a/example/bounds/bounds.collection
+++ b/example/bounds/bounds.collection
@@ -78,6 +78,11 @@ instances {
       value: "0.0"
       type: PROPERTY_TYPE_NUMBER
     }
+    properties {
+      id: "crosshair"
+      value: "false"
+      type: PROPERTY_TYPE_BOOLEAN
+    }
   }
   scale3 {
     x: 1.0

--- a/example/bounds/bounds.collection
+++ b/example/bounds/bounds.collection
@@ -63,7 +63,7 @@ instances {
   position {
     x: 158.0
     y: 161.0
-    z: 1.0
+    z: 0.5
   }
   rotation {
     x: 0.0

--- a/example/bounds/bounds.collection
+++ b/example/bounds/bounds.collection
@@ -71,6 +71,14 @@ instances {
     z: 0.0
     w: 1.0
   }
+  component_properties {
+    id: "script"
+    properties {
+      id: "camera_offset_lerp"
+      value: "0.0"
+      type: PROPERTY_TYPE_NUMBER
+    }
+  }
   scale3 {
     x: 1.0
     y: 1.0
@@ -94,6 +102,8 @@ embedded_instances {
   "    z: 0.0\n"
   "    w: 1.0\n"
   "  }\n"
+  "  property_decls {\n"
+  "  }\n"
   "}\n"
   "components {\n"
   "  id: \"bounds\"\n"
@@ -108,6 +118,8 @@ embedded_instances {
   "    y: 0.0\n"
   "    z: 0.0\n"
   "    w: 1.0\n"
+  "  }\n"
+  "  property_decls {\n"
   "  }\n"
   "}\n"
   ""

--- a/example/shared/objects/hitman.script
+++ b/example/shared/objects/hitman.script
@@ -59,6 +59,7 @@ function on_input(self, action_id, action)
 		if self.crosshair and action_id == hash("touch") and action.released then
 			local crosshair_world = go.get_position("crosshair")
 			local player_world = go.get_position()
+			msg.post("@render:", "draw_line", { start_point = player_world, end_point = crosshair_world, color = vmath.vector4(0, 1, 0, 1) } )
 			local offset = (crosshair_world - player_world) * 0.1
 			camera.recoil(CAMERA_ID, offset, 0.5)
 		end


### PR DESCRIPTION
The two changes of note:
- Setting camera_offset_lerp to 0. I did this because it doesn't play nice with deadzone, and it's quite confusing and arguably looks more like a bug than intended behavior.
- Removed the msg.post call to use_projector from camera_controls' init, which intended to set the current projector to DEFAULT. The message handler was erroneously in on_input, so it didn't do actually do anything. If fixed, the camera starts behaving strange. You can also see this by switching to the default camera via the GUI. Because of this I removed the msg.post call rather than fix it.