### PR TITLE
fix: check for GO existence before sending message

### DIFF
--- a/orthographic/camera.script
+++ b/orthographic/camera.script
@@ -118,7 +118,9 @@ function on_message(self, message_id, message, sender)
 		self.viewport_bottom = message.bottom or 0
 	elseif message_id == camera.MSG_SHAKE then
 		camera.shake(self.id, message.intensity, message.duration, message.direction, function()
-			msg.post(sender, camera.MSG_SHAKE_COMPLETED)
+			if go.exists(sender) then
+				msg.post(sender, camera.MSG_SHAKE_COMPLETED)
+			end
 		end)
 	elseif message_id == camera.MSG_RECOIL then
 		camera.recoil(self.id, message.offset, message.duration)


### PR DESCRIPTION
The camera was calling `msg.post(sender, MSG_SHAKE_COMPLETED)` without checking if sender is still present at that point. Since this is a callback, the shake can end at a point in time where the sender is no longer alive.

Sample error produced when this happens below :
`ERROR:GAMEOBJECT: Instance '/instance80' could not be found when dispatching message 'shake_completed' sent from game:/camera#script`